### PR TITLE
Fix Issues with spaces

### DIFF
--- a/installer/installer
+++ b/installer/installer
@@ -199,7 +199,7 @@ validateCommand
 
 echo "-----"
 echo "Installing database"
-php -f install/install.php mysqlHost=${mysqlhost} mysqlUser=${mysqluser} mysqlPass=${mysqlpass} companyName=${companyname} siteUrl=${siteurl} adminName=${adminname} adminEmail=${adminemail} adminPass=${adminpass}
+php -f install/install.php mysqlHost="$mysqlhost" mysqlUser="$mysqluser" mysqlPass="$mysqlpass" companyName="$companyname" siteUrl="$siteurl" adminName="$adminname" adminEmail="$adminemail" adminPass="$adminpass"
 if [ $? -ne 0 ]; then
     echo -e "${red}An error occured while installing, halting${normal}";
     revertInstall


### PR DESCRIPTION
Replaced Curly Brackets {} with Quote marks"".

Installed still operates and you can have spaces in Company Names. 
