### PR TITLE
fix broken installer / misinterpreation

### DIFF
--- a/installer/installer
+++ b/installer/installer
@@ -21,9 +21,9 @@ adminemail="admin@examplehost.com"
 
 #Check distro and set proper webuser
 distro=`. /etc/os-release 2>/dev/null; echo $ID`
-if [ "${distro}" -eq "ubuntu" ]; then
+if [[ "${distro}" -eq "ubuntu" ]]; then
     webuser="www-data";
-elif [ "${distro}"" -eq "debian" ]; then
+elif [[ "${distro}" -eq "debian" ]]; then
     webuser="www-data";
 fi
 


### PR DESCRIPTION
This error occurred because there was one quotation mark too much. Also you need to use double brackets when you want to compare strings with each other in bash. Please merge this fast because without this fix the installer is completely broken.
